### PR TITLE
Feature/config command/edit subcommand rework

### DIFF
--- a/src/core/cli.rs
+++ b/src/core/cli.rs
@@ -57,7 +57,7 @@ pub mod arguments {
         pub persister: Option<String>,
 
         /// Identifiers of tasks separated by commas.
-        #[arg(value_delimiter = ',')]
+        #[arg(value_delimiter = ',', required = true)]
         pub ids: Vec<u32>,
     }
 
@@ -81,7 +81,7 @@ pub mod arguments {
         pub priority: Priority,
 
         /// Identifiers of tasks separated by commas.
-        #[arg(value_delimiter = ',')]
+        #[arg(value_delimiter = ',', required = true)]
         pub ids: Vec<u32>,
     }
 
@@ -92,7 +92,7 @@ pub mod arguments {
         pub content: String,
 
         /// Identifiers of tasks separated by commas.
-        #[arg(value_delimiter = ',')]
+        #[arg(value_delimiter = ',', required = true)]
         pub ids: Vec<u32>,
     }
 
@@ -112,6 +112,26 @@ pub mod arguments {
         /// Subcommand the 'Config' command will use.
         #[command(subcommand)]
         pub subcommand: sub::Config,
+    }
+
+    /// Arguments for the 'config set' subcommand
+    #[derive(Args, Clone, Debug, PartialEq, Eq)]
+    pub struct ConfigSet {
+        /// Defines where tasks are stored. It can be the path to a file or a database connection string (including protocol).
+        #[arg(long, value_name = "STRING")]
+        pub persister: Option<String>,
+
+        /// If 'true', allows dropping tasks without them being checked.
+        #[arg(long, value_name = "BOOL", value_parser = clap::value_parser!(bool))]
+        pub force_drop: Option<bool>,
+
+        /// If 'true', allows overwriting files if they already exist.
+        #[arg(long, value_name = "BOOL", value_parser = clap::value_parser!(bool))]
+        pub force_copy: Option<bool>,
+
+        /// If 'true', drops the old file after copying its contents to the new file.
+        #[arg(long, value_name = "BOOL", value_parser = clap::value_parser!(bool))]
+        pub drop_after_copy: Option<bool>,
     }
 }
 
@@ -137,10 +157,12 @@ pub mod subcommands {
         Init,
         /// Shows the config file path.
         Path,
-        /// Opens the default editor (via the EDITOR env var) to edit the file
-        Edit,
         /// Deletes the config file
         Drop,
+        /// Displays a list of the current config values.
+        List,
+        /// Changes the values of config properties.
+        Set(args::ConfigSet),
     }
 
     /// Subcommands for the 'Flag' command

--- a/src/core/cli.rs
+++ b/src/core/cli.rs
@@ -122,15 +122,15 @@ pub mod arguments {
         pub persister: Option<String>,
 
         /// If 'true', allows dropping tasks without them being checked.
-        #[arg(long, value_name = "BOOL", value_parser = clap::value_parser!(bool))]
+        #[arg(long, value_name = "BOOL")]
         pub force_drop: Option<bool>,
 
         /// If 'true', allows overwriting files if they already exist.
-        #[arg(long, value_name = "BOOL", value_parser = clap::value_parser!(bool))]
+        #[arg(long, value_name = "BOOL")]
         pub force_copy: Option<bool>,
 
         /// If 'true', drops the old file after copying its contents to the new file.
-        #[arg(long, value_name = "BOOL", value_parser = clap::value_parser!(bool))]
+        #[arg(long, value_name = "BOOL")]
         pub drop_after_copy: Option<bool>,
     }
 }

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -196,7 +196,18 @@ impl Config {
     }
 
     /// Sets a value for the passed key.
+    ///
+    /// # Panics
+    /// If there are no values provided.
     pub fn set(args: args::ConfigSet) {
+        if args.persister.is_none()
+            && args.force_drop.is_none()
+            && args.force_copy.is_none()
+            && args.drop_after_copy.is_none()
+        {
+            panic!("You must provide a flag and value to set");
+        }
+
         let mut config = Self::load();
 
         if let Some(persister) = args.persister {

--- a/src/core/postit.rs
+++ b/src/core/postit.rs
@@ -32,7 +32,7 @@ impl Postit {
             Command::Copy(args) => Self::copy(args),
             Command::Clean(args) => Self::clean(args),
             Command::Remove(args) => Self::remove(args),
-            Command::Config(args) => Self::config(&args),
+            Command::Config(args) => Self::config(args),
         }
     }
 
@@ -150,7 +150,7 @@ impl Postit {
     }
 
     /// Manages the configuration file.   
-    fn config(args: &args::Config) {
-        Config::manage(&args.subcommand);
+    fn config(args: args::Config) {
+        Config::manage(args.subcommand);
     }
 }

--- a/src/docs/command.rs
+++ b/src/docs/command.rs
@@ -379,7 +379,7 @@ How to use:
 
 Default config:
     After running 'postit config init', postit will generate a file with the
-    default settings:
+    default settings, which you can change by using 'postit config set [OPTIONS]':
 
     - persister (string): 'tasks.csv' by default.
       Defines where tasks are stored (the '-p' or '--persister' flag can override this).

--- a/src/docs/command.rs
+++ b/src/docs/command.rs
@@ -361,29 +361,38 @@ Description:
 
     Available subcommands:
     - init: creates the .postit.toml file.
-    - edit: executes the editor (EDITOR env var) to change configs.
-    - drop: deletes the config file (default values will be used at runtime).
+    - path: displays the path of the config file.
+    - drop: deletes the config file.
+    - list: displays a list of the current config values.
+    - set: changes the values of config properties.
 
 How to use:
     postit config init
 
-    postit config edit
+    postit config path
 
     postit config drop
+
+    postit config list
+
+    postit config set [OPTIONS]
 
 Default config:
     After running 'postit config init', postit will generate a file with the
     default settings:
 
-    - persister: where tasks are stored (the '-p' or '--persister' flag can override this).
-    It can be one of the supported persisters (file or database).
+    - persister (string): 'tasks.csv' by default.
+      Defines where tasks are stored (the '-p' or '--persister' flag can override this).
+      It can be the path to a file or a database connection string (including protocol).
 
-    - force_drop: if true, allows dropping tasks even if they are not checked.
+    - force_drop (bool): false by default.
+      If 'true', allows dropping tasks even if they are not checked.
 
-    - force_copy: if true, allows overwriting tasks on populated persisters when
-      using the 'copy' command.
+    - force_copy (bool): false by default.
+      If 'true', allows overwriting persisters when using the 'copy' command.
 
-    - drop_after_copy: if true, drops a persister (file or table) after copying.
+    - drop_after_copy (bool): false by default.
+      If 'true', drops a persister (file or table) after copying.
     
     You can also check https://docs.rs/postit/latest/postit/struct.Config.html for more info."
         );

--- a/tests/core/config.rs
+++ b/tests/core/config.rs
@@ -12,7 +12,7 @@ use crate::mocks::{MockConfig, MockConn, MockPath};
 fn manage_print_path() {
     let mock = MockConfig::new();
 
-    Config::manage(&sub::Config::Path);
+    Config::manage(sub::Config::Path);
 
     assert!(mock.path().exists());
 }
@@ -65,7 +65,7 @@ fn print_path_not_exists_panics() {
 fn manage_init() {
     let mock = MockConfig::new();
 
-    Config::manage(&sub::Config::Init);
+    Config::manage(sub::Config::Init);
 
     let result = Config::load();
     let expect = Config::default();
@@ -75,34 +75,11 @@ fn manage_init() {
 }
 
 #[test]
-fn manage_edit() {
-    let key = "EDITOR";
-    let value = std::env::var(key).unwrap();
-
-    std::env::set_var(key, "echo");
-    Config::manage(&sub::Config::Edit);
-
-    std::env::set_var(key, value);
-}
-
-#[test]
-#[should_panic]
-fn manage_edit_panics() {
-    let key = "EDITOR";
-    let value = std::env::var(key).unwrap();
-
-    std::env::set_var(key, "");
-    Config::manage(&sub::Config::Edit);
-
-    std::env::set_var(key, value);
-}
-
-#[test]
 fn manage_drop() {
     let mock = MockConfig::new();
 
-    Config::manage(&sub::Config::Init);
-    Config::manage(&sub::Config::Drop);
+    Config::manage(sub::Config::Init);
+    Config::manage(sub::Config::Drop);
 
     assert!(mock.path().exists().not());
 }
@@ -110,7 +87,7 @@ fn manage_drop() {
 #[test]
 #[should_panic]
 fn manage_drop_panics() {
-    Config::manage(&sub::Config::Drop);
+    Config::manage(sub::Config::Drop);
 }
 
 #[test]
@@ -151,21 +128,6 @@ fn path_custom() {
     let expect = PathBuf::from("tmp/.postit.toml");
 
     assert_eq!(result, expect);
-}
-
-#[test]
-fn editor_custom() {
-    let value = Config::editor();
-
-    std::env::set_var("EDITOR", "code");
-    assert!(Config::editor().contains("code"));
-
-    std::env::set_var("EDITOR", value);
-}
-
-#[test]
-fn editor_default() {
-    assert!(Config::editor().contains("nano"));
 }
 
 #[test]


### PR DESCRIPTION
# New
- Added 'list' subcommand to the 'config' command to show the current configuration.
- Added 'set' subcommand to the 'config' command to change configuration values.

# Changes
- Replaced the 'edit' subcommand with 'set'.