### PR TITLE
Feature/generate files inside postit root

### DIFF
--- a/src/core/cli.rs
+++ b/src/core/cli.rs
@@ -76,24 +76,24 @@ pub mod arguments {
     /// Arguments of the 'set priority' subcommand.
     #[derive(Args, Debug)]
     pub struct SetPriority {
-        /// Priority of the task (none, low, med or high).
-        #[arg(value_enum)]
-        pub priority: Priority,
-
         /// Identifiers of tasks separated by commas.
         #[arg(value_delimiter = ',', required = true)]
         pub ids: Vec<u32>,
+
+        /// Priority of the task (none, low, med or high).
+        #[arg(value_enum)]
+        pub priority: Priority,
     }
 
     /// Arguments of the 'set content' subcommand.
     #[derive(Args, Debug)]
     pub struct SetContent {
-        /// The content or description of a task.
-        pub content: String,
-
         /// Identifiers of tasks separated by commas.
         #[arg(value_delimiter = ',', required = true)]
         pub ids: Vec<u32>,
+
+        /// The content or description of a task.
+        pub content: String,
     }
 
     /// Arguments of the 'copy' command.

--- a/src/core/cli.rs
+++ b/src/core/cli.rs
@@ -155,10 +155,12 @@ pub mod subcommands {
     pub enum Config {
         /// Creates the config file.
         Init,
-        /// Shows the config file path.
-        Path,
         /// Deletes the config file
         Drop,
+        /// Shows the value of the `POSTIT_ROOT` env var.
+        Env,
+        /// Shows the config file path.
+        Path,
         /// Displays a list of the current config values.
         List,
         /// Changes the values of config properties.
@@ -243,7 +245,7 @@ pub enum Command {
     #[command(alias = "rm")]
     Remove(args::Persister),
 
-    /// Manages the configuration file (.postit.toml).
+    /// Manages the configuration file.
     #[command(alias = "conf")]
     Config(args::Config),
 

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -125,7 +125,8 @@ impl Config {
         let path = &Self::path();
 
         if !path.exists() {
-            panic!("Config file doesn't exist.");
+            eprintln!("Config file doesn't exist at {}", path.display());
+            return;
         }
 
         fs::remove_file(path).expect("Config file couldn't be deleted.");
@@ -253,8 +254,8 @@ impl Config {
         let mut parent = Self::get_parent_path();
         let parent_str = parent.to_str().unwrap();
 
-        if parent_str.starts_with(path_str) || parent_str.contains(path_str) {
-            return Self::path();
+        if path_str.starts_with(parent_str) || path_str.contains(parent_str) {
+            return path.as_ref().to_path_buf();
         }
 
         parent.push(path);

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -94,6 +94,7 @@ impl Config {
     /// Manages the `.postit.toml` file using a `ConfigSubcommand` instance.
     pub fn manage(subcommand: sub::Config) {
         match subcommand {
+            sub::Config::Env => Self::print_env(),
             sub::Config::Path => Self::print_path(),
             sub::Config::Init => Self::init(),
             sub::Config::Drop => Self::drop(),
@@ -126,6 +127,20 @@ impl Config {
             .expect("Failed to write default config to file");
 
         println!("Config file created at '{}'", path.to_str().unwrap());
+    }
+
+    /// Prints the value of the `POSTIT_ROOT` env var.
+    ///
+    /// # Panics
+    /// If `POSTIT_ROOT` is empty.
+    pub fn print_env() {
+        let env = Self::env_var();
+
+        if !env.is_empty() {
+            return println!("{env}");
+        }
+
+        panic!("The 'POSTIT_ROOT' environment variable is empty");
     }
 
     /// Prints the path of the config file.

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -4,7 +4,7 @@ pub mod cli;
 mod config;
 mod postit;
 
-/// Possible actions taken when editing a persister's contents.
+/// Possible actions taken when editing a persister's tasks.
 pub enum Action {
     /// Used to check tasks.
     Check,
@@ -12,6 +12,10 @@ pub enum Action {
     Uncheck,
     /// Used to drop tasks.
     Drop,
+    /// Used to set the content of tasks.
+    SetContent,
+    /// Used to set the priority of tasks.
+    SetPriority,
 }
 
 pub use cli::{Cli, Command};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,12 +23,8 @@
 #![allow(
     clippy::cast_sign_loss,
     clippy::cast_possible_truncation,
-    clippy::or_fun_call,
     clippy::manual_assert,
-    clippy::match_wildcard_for_single_variants,
-    clippy::module_name_repetitions,
-    clippy::must_use_candidate,
-    clippy::return_self_not_must_use
+    clippy::must_use_candidate
 )]
 
 mod core;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,9 @@
     clippy::cast_sign_loss,
     clippy::cast_possible_truncation,
     clippy::manual_assert,
-    clippy::must_use_candidate
+    clippy::must_use_candidate,
+    // TEMP
+    clippy::needless_pass_by_value
 )]
 
 mod core;

--- a/src/models/todo.rs
+++ b/src/models/todo.rs
@@ -32,9 +32,9 @@ impl Todo {
     /// Initializes a Todo instance with fake data.
     pub fn sample() -> Self {
         Self::new(vec![
-            Task::from("1,Task,low,false"),
+            Task::from("1,Task,high,false"),
             Task::from("2,Task,med,false"),
-            Task::from("3,Task,high,true"),
+            Task::from("3,Task,low,true"),
             Task::from("4,Task,none,true"),
         ])
     }

--- a/src/persisters/db/orm.rs
+++ b/src/persisters/db/orm.rs
@@ -10,6 +10,7 @@ use super::Sqlite;
 use crate::core::Action;
 use crate::models::{Task, Todo};
 use crate::traits::{DbPersister, Persister};
+use crate::Config;
 
 /// Defines errors related to database management.
 pub mod error {
@@ -118,6 +119,9 @@ impl Orm {
 
     /// Returns a struct that implements the [`DbPersister`] trait based on
     /// a connection string.
+    ///
+    /// # Panics
+    /// If the path can't be converted to str.
     pub fn get_persister(conn: &str) -> Box<dyn DbPersister> {
         let conn = String::from(conn);
         let mut parts: Vec<&str> = conn.split("://").collect();
@@ -134,7 +138,7 @@ impl Orm {
         }
 
         match Protocol::from(protocol) {
-            Protocol::Sqlite => Sqlite::from(&conn).boxed(),
+            Protocol::Sqlite => Sqlite::from(Config::build_path(&conn).to_str().unwrap()).boxed(),
         }
     }
 }

--- a/src/persisters/db/orm.rs
+++ b/src/persisters/db/orm.rs
@@ -164,10 +164,6 @@ impl Persister for Orm {
     }
 
     fn edit(&self, todo: &Todo, ids: &[u32], action: Action) {
-        if matches!(action, Action::Drop) {
-            return self.db.delete(ids);
-        }
-
         self.db.update(todo, ids, action);
     }
 

--- a/src/persisters/db/orm.rs
+++ b/src/persisters/db/orm.rs
@@ -7,9 +7,9 @@ use std::fmt;
 use std::ops::Deref;
 
 use super::Sqlite;
-use crate::core::Action;
 use crate::models::{Task, Todo};
 use crate::traits::{DbPersister, Persister};
+use crate::Action;
 
 /// Defines errors related to database management.
 pub mod error {
@@ -163,8 +163,12 @@ impl Persister for Orm {
         self.db.select()
     }
 
-    fn edit(&self, ids: &[u32], action: Action) {
-        self.db.update(ids, action);
+    fn edit(&self, todo: &Todo, ids: &[u32], action: Action) {
+        if matches!(action, Action::Drop) {
+            return self.db.delete(ids);
+        }
+
+        self.db.update(todo, ids, action);
     }
 
     fn save(&self, todo: &Todo) {

--- a/src/persisters/db/orm.rs
+++ b/src/persisters/db/orm.rs
@@ -10,7 +10,6 @@ use super::Sqlite;
 use crate::core::Action;
 use crate::models::{Task, Todo};
 use crate::traits::{DbPersister, Persister};
-use crate::Config;
 
 /// Defines errors related to database management.
 pub mod error {
@@ -138,7 +137,7 @@ impl Orm {
         }
 
         match Protocol::from(protocol) {
-            Protocol::Sqlite => Sqlite::from(Config::build_path(&conn).to_str().unwrap()).boxed(),
+            Protocol::Sqlite => Sqlite::from(&conn).boxed(),
         }
     }
 }

--- a/src/persisters/db/sqlite.rs
+++ b/src/persisters/db/sqlite.rs
@@ -189,7 +189,7 @@ impl DbPersister for Sqlite {
         let value = match action {
             Action::Check => true,
             Action::Uncheck => false,
-            _ => unreachable!(),
+            Action::Drop => unreachable!(),
         };
 
         let ids = self.format_ids(ids);

--- a/src/persisters/db/sqlite.rs
+++ b/src/persisters/db/sqlite.rs
@@ -18,7 +18,10 @@ pub struct Sqlite {
 
 impl Clone for Sqlite {
     fn clone(&self) -> Self {
-        Self::from(&self.conn())
+        Self {
+            conn_str: self.conn_str.clone(),
+            connection: sqlite::open(&self.conn_str).unwrap(),
+        }
     }
 }
 

--- a/src/persisters/db/sqlite.rs
+++ b/src/persisters/db/sqlite.rs
@@ -7,6 +7,7 @@ use sqlite::{Connection, State, Statement};
 use crate::core::Action;
 use crate::models::{Task, Todo};
 use crate::traits::DbPersister;
+use crate::Config;
 
 /// Representation of a `SQLite` database.
 pub struct Sqlite {
@@ -29,11 +30,15 @@ impl Sqlite {
     /// Creates a `Sqlite` instance from a connection string.
     ///
     /// # Panics
+    /// If the path can't be converted to str.
     /// If a connection to the `SQLite` file can't be opened.
     pub fn from(conn: &str) -> Self {
+        let path = Config::build_path(conn);
+        let path_str = path.to_str().unwrap();
+
         let instance = Self {
-            conn_str: String::from(conn),
-            connection: sqlite::open(conn).unwrap(),
+            conn_str: String::from(path_str),
+            connection: sqlite::open(path).unwrap(),
         };
 
         if !instance.exists() {

--- a/src/persisters/db/sqlite.rs
+++ b/src/persisters/db/sqlite.rs
@@ -189,6 +189,10 @@ impl DbPersister for Sqlite {
     }
 
     fn update(&self, todo: &Todo, ids: &[u32], action: Action) {
+        if matches!(action, Action::Drop) {
+            return self.delete(ids);
+        }
+
         let (field, value) = match action {
             Action::Check => ("checked", "1"),
             Action::Uncheck => ("checked", "0"),

--- a/src/persisters/fs/csv.rs
+++ b/src/persisters/fs/csv.rs
@@ -71,7 +71,7 @@ impl FilePersister for Csv {
 
     fn read(&self) -> Vec<String> {
         fs::read_to_string(&self.path)
-            .expect("Should have been able to read the file")
+            .expect("Should have been able to read the CSV file")
             .lines()
             .map(|line| line.replace('\r', ""))
             .filter(|line| !line.is_empty())

--- a/src/persisters/fs/file.rs
+++ b/src/persisters/fs/file.rs
@@ -80,8 +80,6 @@ impl Deref for Format {
 pub struct File {
     /// File that implements the [`FilePersister`] trait.
     file: Box<dyn FilePersister>,
-    /// Path of the file persister.
-    path: PathBuf,
 }
 
 impl fmt::Debug for File {
@@ -99,9 +97,11 @@ impl File {
     /// # Panics
     /// If the file name can't be extracted from the persister path.
     pub fn new(persister: Box<dyn FilePersister>) -> Self {
-        let path = Config::build_path(persister.path().file_name().unwrap());
+        let path = persister.path();
+        let file_name = path.file_name().unwrap();
+        let file_path = Config::build_path(file_name);
 
-        Self { file: persister, path }
+        Self { file: Self::get_persister(file_path) }
     }
 
     /// Creates a `File` instance from a path.
@@ -117,7 +117,7 @@ impl File {
     /// # Panics
     /// In case the persister can't be populated with the default contents.
     pub fn check_content(&self) {
-        let path = &self.path;
+        let path = &self.file.path();
 
         if path.exists() {
             return;
@@ -178,11 +178,11 @@ impl Persister for File {
     }
 
     fn to_string(&self) -> String {
-        self.path.to_str().unwrap().to_owned()
+        self.file.path().to_str().unwrap().to_owned()
     }
 
     fn exists(&self) -> bool {
-        self.path.exists()
+        self.file.path().exists()
     }
 
     fn tasks(&self) -> Vec<Task> {

--- a/src/persisters/fs/file.rs
+++ b/src/persisters/fs/file.rs
@@ -130,7 +130,7 @@ impl File {
 
         let file_name = path
             .file_name()
-            .unwrap_or(OsStr::new("tasks"))
+            .unwrap_or_else(|| OsStr::new("tasks"))
             .to_string_lossy()
             .into_owned();
 

--- a/src/persisters/fs/file.rs
+++ b/src/persisters/fs/file.rs
@@ -9,10 +9,9 @@ use std::path::PathBuf;
 use std::{fmt, fs};
 
 use super::{Csv, Json, Xml};
-use crate::core::Action;
 use crate::models::{Task, Todo};
 use crate::traits::{FilePersister, Persister};
-use crate::Config;
+use crate::{Action, Config};
 
 /// Defines errors related to file management.
 pub mod error {
@@ -194,16 +193,8 @@ impl Persister for File {
         self.file.read()
     }
 
-    fn edit(&self, ids: &[u32], action: Action) {
-        let mut todo = Todo::from(self);
-
-        match action {
-            Action::Check => todo.check(ids),
-            Action::Uncheck => todo.uncheck(ids),
-            Action::Drop => todo.drop(ids),
-        };
-
-        self.file.write(&todo);
+    fn edit(&self, todo: &Todo, _ids: &[u32], _action: Action) {
+        self.file.write(todo);
     }
 
     fn save(&self, todo: &Todo) {

--- a/src/persisters/fs/file.rs
+++ b/src/persisters/fs/file.rs
@@ -217,7 +217,7 @@ impl Persister for File {
         }
 
         if let (Some(file), Some(parent)) = (path.file_name(), path.parent()) {
-            eprintln!("The file {} doesn't exist at {}", file.display(), parent.display());
+            eprintln!("The file {:?} doesn't exist at {}", file, parent.display());
         }
     }
 }

--- a/src/persisters/fs/json.rs
+++ b/src/persisters/fs/json.rs
@@ -59,7 +59,7 @@ impl FilePersister for Json {
 
     fn read(&self) -> Vec<String> {
         fs::read_to_string(&self.path)
-            .expect("Should have been able to read the file")
+            .expect("Should have been able to read the JSON file")
             .lines()
             .map(|line| line.replace('\r', ""))
             .filter(|line| !line.is_empty())

--- a/src/persisters/fs/xml.rs
+++ b/src/persisters/fs/xml.rs
@@ -179,7 +179,7 @@ impl FilePersister for Xml {
 
     fn read(&self) -> Vec<String> {
         fs::read_to_string(&self.path)
-            .expect("Should have been able to read the file")
+            .expect("Should have been able to read the XML file")
             .lines()
             .map(|line| line.replace('\r', ""))
             .filter(|line| !line.is_empty())

--- a/src/persisters/traits.rs
+++ b/src/persisters/traits.rs
@@ -3,8 +3,8 @@
 use std::path::PathBuf;
 use std::{fmt, fs};
 
-use crate::core::Action;
 use crate::models::{Task, Todo};
+use crate::Action;
 
 /// The `Persister` trait serves as a base for structures that store instances
 /// of other structs that contain either the [`FilePersister`] trait or the
@@ -26,7 +26,7 @@ pub trait Persister: fmt::Debug {
     fn read(&self) -> Vec<String>;
 
     /// Edits a persister by managing an [`Action`] variant.
-    fn edit(&self, ids: &[u32], action: Action);
+    fn edit(&self, todo: &Todo, ids: &[u32], action: Action);
 
     /// Saves a Todo instance as the persister's content.
     fn save(&self, todo: &Todo);
@@ -119,7 +119,7 @@ pub trait DbPersister {
     fn insert(&self, todo: &Todo);
 
     /// Updates data from a table.
-    fn update(&self, ids: &[u32], action: Action);
+    fn update(&self, todo: &Todo, ids: &[u32], action: Action);
 
     /// Drops data from a table.
     fn delete(&self, ids: &[u32]);

--- a/tests/core/config.rs
+++ b/tests/core/config.rs
@@ -113,12 +113,6 @@ fn env_is_empty() {
 }
 
 #[test]
-fn env_is_output() {
-    // todo!();
-    //     std::env::set_var("POSTIT_ROOT", "");
-}
-
-#[test]
 fn manage_init() {
     let mock = MockConfig::new();
 
@@ -139,12 +133,6 @@ fn manage_drop() {
     Config::manage(sub::Config::Drop);
 
     assert!(mock.path().exists().not());
-}
-
-#[test]
-#[should_panic]
-fn manage_drop_panics() {
-    Config::manage(sub::Config::Drop);
 }
 
 #[test]

--- a/tests/core/config.rs
+++ b/tests/core/config.rs
@@ -54,6 +54,15 @@ fn path_exists_output() {
 }
 
 #[test]
+fn print_path_not_exists_error() {
+    let _mock = MockConfig::new();
+
+    Config::drop();
+
+    Config::print_path();
+}
+
+#[test]
 fn path_not_exists_output() {
     let mock = MockConfig::new();
 
@@ -67,18 +76,8 @@ fn path_not_exists_output() {
 
     let stderr = String::from_utf8_lossy(&output.stderr);
 
-    assert!(output.status.success().not());
+    assert!(output.status.success());
     assert!(stderr.contains(mock.path().parent().unwrap().to_str().unwrap()));
-}
-
-#[test]
-#[should_panic]
-fn print_path_not_exists_panics() {
-    let _mock = MockConfig::new();
-
-    Config::drop();
-
-    Config::print_path();
 }
 
 #[test]
@@ -107,11 +106,16 @@ fn env_output() {
 }
 
 #[test]
-#[should_panic]
 fn env_is_empty() {
     std::env::set_var("POSTIT_ROOT", "");
 
     Config::print_env();
+}
+
+#[test]
+fn env_is_output() {
+    // todo!();
+    //     std::env::set_var("POSTIT_ROOT", "");
 }
 
 #[test]
@@ -296,7 +300,7 @@ fn save() {
 fn save_file_doesnt_exist() {
     let _mock = MockConfig::new();
 
-    std::env::set_var("POSTIT_ROOT", " ");
+    std::env::set_var("POSTIT_ROOT", "//");
 
     let default = Config::default();
     default.save();
@@ -309,7 +313,7 @@ fn resolve_persister_file() {
     let mock = MockPath::create(Format::Csv);
     let persister = Config::resolve_persister(Some(mock.to_string()));
 
-    assert_eq!(persister.to_string(), mock.to_string())
+    assert_eq!(PathBuf::from(persister.to_string()), mock.path())
 }
 
 #[test]
@@ -322,10 +326,12 @@ fn resolve_persister_db() {
 
 #[test]
 fn resolve_persister_none() {
-    let _mock = MockConfig::new();
     let persister = Config::resolve_persister(None).to_string();
 
-    assert_eq!(persister.to_string(), Config::load().persister);
+    let mut path = Config::get_parent_path();
+    path.push(Config::load().persister);
 
-    MockPath::new(PathBuf::from("tasks.csv"));
+    assert_eq!(persister.to_string(), path.to_str().unwrap());
+
+    MockPath::create(Format::Csv);
 }

--- a/tests/core/config.rs
+++ b/tests/core/config.rs
@@ -29,7 +29,7 @@ drop_after_copy: true";
 }
 
 #[test]
-fn manage_print_path() {
+fn manage_path() {
     let mock = MockConfig::new();
 
     Config::manage(sub::Config::Path);
@@ -38,7 +38,7 @@ fn manage_print_path() {
 }
 
 #[test]
-fn manage_print_path_exists_output() {
+fn path_exists_output() {
     let mock = MockConfig::new();
 
     let output = assert_cmd::Command::cargo_bin("postit")
@@ -54,7 +54,7 @@ fn manage_print_path_exists_output() {
 }
 
 #[test]
-fn print_path_not_exists_output() {
+fn path_not_exists_output() {
     let mock = MockConfig::new();
 
     Config::drop();
@@ -79,6 +79,39 @@ fn print_path_not_exists_panics() {
     Config::drop();
 
     Config::print_path();
+}
+
+#[test]
+fn manage_env() {
+    let mock = MockConfig::new();
+
+    Config::manage(sub::Config::Env);
+
+    assert!(mock.path().exists());
+}
+
+#[test]
+fn env_output() {
+    let _mock = MockConfig::new();
+
+    let output = assert_cmd::Command::cargo_bin("postit")
+        .unwrap()
+        .args(["config", "env"])
+        .output()
+        .expect("Error while running the test");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(output.status.success());
+    assert!(stdout.contains(&Config::env_var()));
+}
+
+#[test]
+#[should_panic]
+fn env_is_empty() {
+    std::env::set_var("POSTIT_ROOT", "");
+
+    Config::print_env();
 }
 
 #[test]

--- a/tests/core/postit.rs
+++ b/tests/core/postit.rs
@@ -266,18 +266,19 @@ fn copy() {
     mock_config.save();
 
     let mock_left = MockPath::create(Format::Csv);
-    let right = "postit_copy.json";
+    let right_path = Config::build_path("postit_copy.json");
+    let right_str = right_path.to_str().unwrap();
 
     let cli = Cli {
         command: Command::Copy(args::Copy {
             left: mock_left.to_string(),
-            right: right.to_string(),
+            right: right_str.to_string(),
         }),
     };
 
     Postit::run(cli);
 
-    let mock_right = MockPath::new(PathBuf::from(right));
+    let mock_right = MockPath::new(right_path);
 
     let (left_file, left_todo) = expected(&mock_left);
     let (right_file, right_todo) = expected(&mock_right);

--- a/tests/core/postit.rs
+++ b/tests/core/postit.rs
@@ -106,7 +106,7 @@ fn set_priority() {
 
     Postit::run(cli);
 
-    let tasks = todo.get(&ids);
+    let tasks = todo.get_mut(&ids);
 
     for task in tasks {
         task.priority = priority.clone();
@@ -140,7 +140,7 @@ fn set_content() {
 
     Postit::run(cli);
 
-    let tasks = todo.get(&ids);
+    let tasks = todo.get_mut(&ids);
 
     for task in tasks {
         task.content = content.clone();

--- a/tests/mocks.rs
+++ b/tests/mocks.rs
@@ -128,9 +128,9 @@ impl MockConn {
     }
 
     pub fn sqlite() -> Self {
-        let instance = Sqlite::from("test_tasks.db").boxed();
-
-        Self { instance }
+        Self {
+            instance: Sqlite::from("test_tasks.db").boxed(),
+        }
     }
 }
 

--- a/tests/models/todo.rs
+++ b/tests/models/todo.rs
@@ -46,7 +46,7 @@ fn get() {
     let clone = todo.clone();
 
     let ids = vec![2, 3];
-    let tasks = todo.get(&ids);
+    let tasks = todo.get_mut(&ids);
     let expect = vec![&clone.tasks[1], &clone.tasks[2]];
 
     assert_eq!(tasks, expect);

--- a/tests/models/todo.rs
+++ b/tests/models/todo.rs
@@ -42,6 +42,20 @@ fn read() {
 fn get() {
     let mock = MockPath::create(Format::Csv);
 
+    let todo = fakes(&mock);
+    let clone = todo.clone();
+
+    let ids = vec![2, 3];
+    let tasks = todo.get(&ids);
+    let expect = vec![&clone.tasks[1], &clone.tasks[2]];
+
+    assert_eq!(tasks, expect);
+}
+
+#[test]
+fn get_mut() {
+    let mock = MockPath::create(Format::Csv);
+
     let mut todo = fakes(&mock);
     let clone = todo.clone();
 

--- a/tests/persisters/db/orm.rs
+++ b/tests/persisters/db/orm.rs
@@ -115,7 +115,7 @@ fn edit_check() {
     let ids = vec![2, 3];
 
     orm.save(&todo);
-    orm.edit(&ids, postit::Action::Check);
+    orm.edit(&todo, &ids, postit::Action::Check);
 
     todo.check(&ids);
 
@@ -133,7 +133,7 @@ fn edit_uncheck() {
     let ids = vec![2, 3];
 
     orm.save(&todo);
-    orm.edit(&ids, postit::Action::Uncheck);
+    orm.edit(&todo, &ids, postit::Action::Uncheck);
 
     todo.uncheck(&ids);
 
@@ -151,7 +151,7 @@ fn edit_drop() {
     let ids = vec![2, 3];
 
     orm.save(&todo);
-    orm.edit(&ids, postit::Action::Drop);
+    orm.edit(&todo, &ids, postit::Action::Drop);
 
     todo.check(&ids);
     todo.drop(&ids);

--- a/tests/persisters/db/orm.rs
+++ b/tests/persisters/db/orm.rs
@@ -3,6 +3,7 @@ use std::ops::Not;
 use postit::db::{Orm, Protocol, Sqlite};
 use postit::models::Task;
 use postit::traits::{DbPersister, Persister};
+use postit::Config;
 
 use crate::mocks::MockConn;
 
@@ -60,7 +61,10 @@ fn get_persister_empty() {
     let _mock = MockConn::new(conn);
     let persister = Orm::get_persister("");
 
-    assert_eq!(persister.conn(), conn)
+    let path = Config::build_path(conn);
+    let conn_str = path.to_str().unwrap();
+
+    assert_eq!(persister.conn(), conn_str)
 }
 
 #[test]

--- a/tests/persisters/db/orm.rs
+++ b/tests/persisters/db/orm.rs
@@ -76,6 +76,14 @@ fn to_string() {
 }
 
 #[test]
+fn exists() {
+    let mock = MockConn::create(Protocol::Sqlite);
+    let orm = Orm::from(&mock.conn());
+
+    assert!(orm.exists())
+}
+
+#[test]
 fn save_twice() {
     let mock = MockConn::create(Protocol::Sqlite);
     let mut todo = MockConn::sample();
@@ -173,6 +181,22 @@ fn tasks() {
     let result = orm.tasks();
 
     assert_eq!(result, todo.tasks)
+}
+
+#[test]
+fn replace() {
+    let mock = MockConn::create(Protocol::Sqlite);
+    let mut todo = MockConn::sample();
+    todo.add(Task::from("5,test,med,false"));
+
+    let orm = Orm::from(&mock.instance.conn());
+
+    orm.replace(&todo);
+
+    let result = orm.tasks();
+    let expect = todo.tasks;
+
+    assert_eq!(result, expect)
 }
 
 #[test]

--- a/tests/persisters/db/sqlite.rs
+++ b/tests/persisters/db/sqlite.rs
@@ -119,7 +119,7 @@ fn insert_and_select() {
 }
 
 #[test]
-fn update_check_ok() {
+fn update_check() {
     let mock = MockConn::create(Protocol::Sqlite);
     let mut todo = MockConn::sample();
 
@@ -149,6 +149,44 @@ fn update_uncheck() {
     mock.instance.update(&todo, &ids, action);
 
     todo.uncheck(&ids);
+
+    let selected = mock.instance.select();
+    let result: Vec<Task> = selected.iter().map(|line| Task::from(line)).collect();
+
+    assert_eq!(result, todo.tasks)
+}
+
+#[test]
+fn update_set_content() {
+    let mock = MockConn::create(Protocol::Sqlite);
+    let mut todo = MockConn::sample();
+
+    let ids = vec![2, 3];
+    let action = Action::SetContent;
+
+    todo.set_content(&ids, "test");
+
+    mock.instance.insert(&todo);
+    mock.instance.update(&todo, &ids, action);
+
+    let selected = mock.instance.select();
+    let result: Vec<Task> = selected.iter().map(|line| Task::from(line)).collect();
+
+    assert_eq!(result, todo.tasks)
+}
+
+#[test]
+fn update_set_priority() {
+    let mock = MockConn::create(Protocol::Sqlite);
+    let mut todo = MockConn::sample();
+
+    let ids = vec![2, 3];
+    let action = Action::SetPriority;
+
+    todo.set_priority(&ids, &postit::models::Priority::High);
+
+    mock.instance.insert(&todo);
+    mock.instance.update(&todo, &ids, action);
 
     let selected = mock.instance.select();
     let result: Vec<Task> = selected.iter().map(|line| Task::from(line)).collect();

--- a/tests/persisters/db/sqlite.rs
+++ b/tests/persisters/db/sqlite.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use postit::db::{Protocol, Sqlite};
 use postit::models::{Task, Todo};
 use postit::traits::DbPersister;
-use postit::Action;
+use postit::{Action, Config};
 
 use crate::mocks::MockConn;
 
@@ -61,7 +61,10 @@ fn conn() {
     let conn = "test.db";
     let mock = MockConn::new(conn);
 
-    assert_eq!(conn, &mock.conn());
+    let path = Config::build_path(conn);
+    let conn_str = path.to_str().unwrap();
+
+    assert_eq!(conn_str, &mock.conn());
 }
 
 #[test]

--- a/tests/persisters/db/sqlite.rs
+++ b/tests/persisters/db/sqlite.rs
@@ -127,7 +127,7 @@ fn update_check_ok() {
     let action = Action::Check;
 
     mock.instance.insert(&todo);
-    mock.instance.update(&ids, action);
+    mock.instance.update(&todo, &ids, action);
 
     todo.check(&ids);
 
@@ -146,7 +146,7 @@ fn update_uncheck() {
     let action = Action::Uncheck;
 
     mock.instance.insert(&todo);
-    mock.instance.update(&ids, action);
+    mock.instance.update(&todo, &ids, action);
 
     todo.uncheck(&ids);
 
@@ -165,7 +165,7 @@ fn update_delete() {
     let action = Action::Drop;
 
     mock.instance.insert(&todo);
-    mock.instance.update(&ids, action);
+    mock.instance.update(&todo, &ids, action);
 
     todo.check(&ids);
     todo.drop(&ids);

--- a/tests/persisters/db/sqlite.rs
+++ b/tests/persisters/db/sqlite.rs
@@ -1,4 +1,5 @@
 use std::ops::Not;
+use std::path::PathBuf;
 
 use postit::db::{Protocol, Sqlite};
 use postit::models::{Task, Todo};
@@ -30,7 +31,10 @@ fn count_table_doesnt_exist() {
     let mock = MockConn::create(Protocol::Sqlite);
     mock.instance.drop_database();
 
-    assert_eq!(Sqlite::from(&mock.conn()).count(), 0);
+    let path = PathBuf::from(mock.conn());
+    let file = path.file_name().unwrap().to_str().unwrap();
+
+    assert_eq!(Sqlite::from(file).count(), 0);
 }
 
 #[test]

--- a/tests/persisters/fs/file.rs
+++ b/tests/persisters/fs/file.rs
@@ -43,7 +43,7 @@ fn check_name_ok() {
     let checked_path = File::check_name(mock_path.clone());
 
     let result = checked_path.file_name().unwrap();
-    let expect = mock_path.as_os_str();
+    let expect = mock_path.file_name().unwrap();
 
     assert_eq!(result, expect);
 }

--- a/tests/persisters/traits.rs
+++ b/tests/persisters/traits.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use postit::db::{Protocol, Sqlite};
 use postit::fs::{Csv, Format};
 use postit::traits::{DbPersister, FilePersister};
@@ -30,7 +32,11 @@ fn file_persister_eq() {
 #[test]
 fn db_persister_eq() {
     let mock = MockConn::create(Protocol::Sqlite);
-    let sqlite = Sqlite::from(&mock.conn());
+
+    let path = PathBuf::from(mock.conn());
+    let file = path.file_name().unwrap().to_str().unwrap();
+
+    let sqlite = Sqlite::from(file);
 
     let left = sqlite.clone().boxed();
     let right = sqlite.boxed();


### PR DESCRIPTION
# New
- Added 'env' subcommand to the 'config' command that prints the value of `POSTIT_ROOT`

# Changed
- All files will be generated inside POSTIT_ROOT (`$HOME/.postit` by default)