### PR TITLE
Feature/copy rework

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,9 @@ postit config init
 ```
 
 Here is a list of useful commands to get started:
-- `postit help`: displays a list of all possible commands.
-- `postit example`: displays an example on how to use every other command.
-- `postit flag`: displays information about commonly used flags.
+- `postit help`: a list of all possible commands.
+- `postit docs`: documentation and use examples for every command.
+- `postit flag`: documentation and use examples for flags.
 
 ## From 0.1.x to 0.2.x
 
@@ -103,10 +103,11 @@ Roadmap:
 
 postit's behavior can be changed using the `.postit.toml` file.
 
-You can check out its possible fields in the [docs](https://docs.rs/postit/latest/postit/struct.Config.html) or by running the example command:
+You can check out its possible fields in the [docs](https://docs.rs/postit/latest/postit/struct.Config.html)
+or by running the documentation command:
 
 ```sh
-postit example config
+postit docs config
 ```
 
 ## Development

--- a/src/core/cli.rs
+++ b/src/core/cli.rs
@@ -10,12 +10,12 @@ pub mod arguments {
     use super::subcommands as sub;
     use crate::models::Priority;
 
-    /// Arguments of the 'example' command.
+    /// Arguments of the 'docs' command.
     #[derive(Args, Debug)]
-    pub struct Example {
-        /// Subcommand the `Example` command will use.
+    pub struct Docs {
+        /// Subcommand the `Docs` command will use.
         #[command(subcommand)]
-        pub subcommand: sub::Example,
+        pub subcommand: sub::Docs,
     }
 
     /// Arguments of the 'flag' command.
@@ -173,34 +173,34 @@ pub mod subcommands {
     /// Subcommands for the 'Flag' command
     #[derive(Subcommand, Debug)]
     pub enum Flag {
-        /// Use example for the 'persister' flag
+        /// Documentation of for the 'persister' flag
         Persister,
     }
 
-    /// Subcommands for the 'Example' command
+    /// Subcommands for the 'Docs' command
     #[derive(Subcommand, Debug)]
-    pub enum Example {
-        /// Use example for the 'config' command
+    pub enum Docs {
+        /// Documentation of the 'config' command
         Config,
-        /// Use example for the 'view' command
+        /// Documentation of the 'view' command
         View,
-        /// Use example for the 'add' command
+        /// Documentation of the 'add' command
         Add,
-        /// Use example for the 'set' command
+        /// Documentation of the 'set' command
         Set,
-        /// Use example for the 'check' command
+        /// Documentation of the 'check' command
         Check,
-        /// Use example for the 'uncheck' command
+        /// Documentation of the 'uncheck' command
         Uncheck,
-        /// Use example for the 'drop' command
+        /// Documentation of the 'drop' command
         Drop,
-        /// Use example for the 'copy' command
+        /// Documentation of the 'copy' command
         Copy,
-        /// Use example for the 'clean' command
+        /// Documentation of the 'clean' command
         Clean,
-        /// Use example for the 'remove' command
+        /// Documentation of the 'remove' command
         Remove,
-        /// Use example for the 'sample' command
+        /// Documentation of the 'sample' command
         Sample,
     }
 }
@@ -252,11 +252,11 @@ pub enum Command {
     #[command(alias = "sa")]
     Sample(args::Persister),
 
-    /// Provides use examples for commands
-    #[command(alias = "ex")]
-    Example(args::Example),
+    /// Provides documentation and use examples for commands
+    #[command(alias = "man")]
+    Docs(args::Docs),
 
-    /// Provides use examples for flags
+    /// Provides documentation and use examples for flags
     #[command(alias = "f")]
     Flag(args::Flag),
 }

--- a/src/core/postit.rs
+++ b/src/core/postit.rs
@@ -32,8 +32,8 @@ impl Postit {
     #[inline]
     pub fn run(cli: Cli) -> super::Result<()> {
         match cli.command {
-            Command::Example(args) => {
-                Self::example(&args);
+            Command::Docs(args) => {
+                Self::docs(&args);
                 Ok(())
             }
             Command::Flag(args) => {
@@ -82,7 +82,7 @@ impl Postit {
     }
 
     /// Shows use cases for every other command.
-    fn example(args: &args::Example) {
+    fn docs(args: &args::Docs) {
         docs::Command::run(&args.subcommand);
     }
 

--- a/src/docs/command.rs
+++ b/src/docs/command.rs
@@ -344,7 +344,18 @@ Config:
 
     If you want to copy your tasks and delete the '<LEFT>' persister, you can do so
     by setting the 'drop_after_copy' config to 'true'. This will delete the file or
-    table located at '<LEFT>'."
+    table located at '<LEFT>'.
+
+Special parameters:
+    There are two special parameters that go into the '<LEFT>' argument.
+
+    Assuming the persister defined at the configuration file is 'tasks.csv':
+
+    - 'from': copies the tasks from '<RIGHT>' to the persister defined at the config.
+      'postit copy from tasks.json' is the same as 'postit copy tasks.json tasks.csv'
+
+    - 'to': copies the tasks from the persister defined at the config to '<RIGHT>'.
+      'postit copy to tasks.json' is the same as 'postit copy tasks.csv tasks.json'"
         );
     }
 

--- a/src/docs/command.rs
+++ b/src/docs/command.rs
@@ -1,4 +1,4 @@
-//! Contains examples of how to use every command, including their usage, alias
+//! Contains documentations for use every command, including their usage, aliases,
 //! a description and a use example to showcase the command's functionalities.
 
 #![allow(clippy::single_call_fn)]
@@ -11,7 +11,7 @@ use crate::models::{Priority, Task, Todo};
 pub struct Command;
 
 impl Command {
-    /// Uses the [`sub::Example`] value passed to show its corresponding example.
+    /// Uses the [`sub::Docs`] value passed to show its corresponding example.
     #[inline]
     pub fn run(cmnd: &sub::Docs) {
         match *cmnd {

--- a/src/docs/command.rs
+++ b/src/docs/command.rs
@@ -13,19 +13,19 @@ pub struct Command;
 impl Command {
     /// Uses the [`sub::Example`] value passed to show its corresponding example.
     #[inline]
-    pub fn run(cmnd: &sub::Example) {
+    pub fn run(cmnd: &sub::Docs) {
         match *cmnd {
-            sub::Example::Config => Self::config(),
-            sub::Example::View => Self::view(),
-            sub::Example::Add => Self::add(),
-            sub::Example::Set => Self::set(),
-            sub::Example::Check => Self::check(),
-            sub::Example::Uncheck => Self::uncheck(),
-            sub::Example::Drop => Self::drop(),
-            sub::Example::Sample => Self::sample(),
-            sub::Example::Copy => Self::copy(),
-            sub::Example::Clean => Self::clean(),
-            sub::Example::Remove => Self::remove(),
+            sub::Docs::Config => Self::config(),
+            sub::Docs::View => Self::view(),
+            sub::Docs::Add => Self::add(),
+            sub::Docs::Set => Self::set(),
+            sub::Docs::Check => Self::check(),
+            sub::Docs::Uncheck => Self::uncheck(),
+            sub::Docs::Drop => Self::drop(),
+            sub::Docs::Sample => Self::sample(),
+            sub::Docs::Copy => Self::copy(),
+            sub::Docs::Clean => Self::clean(),
+            sub::Docs::Remove => Self::remove(),
         }
     }
 

--- a/src/docs/mod.rs
+++ b/src/docs/mod.rs
@@ -1,7 +1,7 @@
 //! Contains commands used for documentation purposes.
 //!
 //! Their information can be accessed by using the following commands:
-//! - postit example <COMMAND>
+//! - postit docs <COMMAND>
 //! - postit flag <COMMAND>
 
 mod command;

--- a/src/persisters/fs/file.rs
+++ b/src/persisters/fs/file.rs
@@ -232,7 +232,7 @@ impl Persister for File {
     #[inline]
     fn tasks(&self) -> crate::Result<Vec<Task>> {
         if !self.exists()? {
-            self.create()?;
+            return Ok(Vec::new());
         }
 
         self.file.tasks().map_err(crate::Error::Fs)

--- a/tests/core/postit.rs
+++ b/tests/core/postit.rs
@@ -62,9 +62,9 @@ fn get_persister_none() -> postit::Result<()> {
 }
 
 #[test]
-fn example() {
+fn docs() {
     let cli = Cli {
-        command: Command::Example(args::Example { subcommand: sub::Example::Add }),
+        command: Command::Docs(args::Docs { subcommand: sub::Docs::Add }),
     };
 
     assert!(Postit::run(cli).is_ok());

--- a/tests/docs/command.rs
+++ b/tests/docs/command.rs
@@ -24,7 +24,7 @@ fn example_sample_output() {
 
 #[test]
 fn example_sample_no_panic() {
-    docs::Command::run(&sub::Example::Sample)
+    docs::Command::run(&sub::Docs::Sample)
 }
 
 #[test]
@@ -39,7 +39,7 @@ fn example_view_output() {
 
 #[test]
 fn example_view_no_panic() {
-    docs::Command::run(&sub::Example::View)
+    docs::Command::run(&sub::Docs::View)
 }
 
 #[test]
@@ -54,7 +54,7 @@ fn example_add_output() {
 
 #[test]
 fn example_add_no_panic() {
-    docs::Command::run(&sub::Example::Add)
+    docs::Command::run(&sub::Docs::Add)
 }
 
 #[test]
@@ -69,7 +69,7 @@ fn example_set_output() {
 
 #[test]
 fn example_set_no_panic() {
-    docs::Command::run(&sub::Example::Set)
+    docs::Command::run(&sub::Docs::Set)
 }
 
 #[test]
@@ -84,7 +84,7 @@ fn example_check_output() {
 
 #[test]
 fn example_check_no_panic() {
-    docs::Command::run(&sub::Example::Check)
+    docs::Command::run(&sub::Docs::Check)
 }
 
 #[test]
@@ -99,7 +99,7 @@ fn example_uncheck_output() {
 
 #[test]
 fn example_uncheck_no_panic() {
-    docs::Command::run(&sub::Example::Uncheck)
+    docs::Command::run(&sub::Docs::Uncheck)
 }
 
 #[test]
@@ -114,7 +114,7 @@ fn example_drop_output() {
 
 #[test]
 fn example_drop_no_panic() {
-    docs::Command::run(&sub::Example::Drop);
+    docs::Command::run(&sub::Docs::Drop);
 }
 
 #[test]
@@ -129,7 +129,7 @@ fn example_copy_output() {
 
 #[test]
 fn example_copy_no_panic() {
-    docs::Command::run(&sub::Example::Copy)
+    docs::Command::run(&sub::Docs::Copy)
 }
 
 #[test]
@@ -144,7 +144,7 @@ fn example_clean_output() {
 
 #[test]
 fn example_clean_no_panic() {
-    docs::Command::run(&sub::Example::Clean)
+    docs::Command::run(&sub::Docs::Clean)
 }
 
 #[test]
@@ -159,7 +159,7 @@ fn example_remove_output() {
 
 #[test]
 fn example_remove_no_panic() {
-    docs::Command::run(&sub::Example::Remove)
+    docs::Command::run(&sub::Docs::Remove)
 }
 
 #[test]
@@ -175,5 +175,5 @@ fn example_config_output() {
 
 #[test]
 fn example_config_no_panic() {
-    docs::Command::run(&sub::Example::Config)
+    docs::Command::run(&sub::Docs::Config)
 }

--- a/tests/docs/command.rs
+++ b/tests/docs/command.rs
@@ -4,17 +4,17 @@ use assert_cmd::Command;
 use postit::cli::subcommands as sub;
 use postit::docs;
 
-fn get_example_output(command: &str) -> Output {
+fn get_docs_output(command: &str) -> Output {
     Command::cargo_bin("postit")
         .unwrap()
-        .args(["example", command])
+        .args(["docs", command])
         .output()
         .expect("Error while running the test")
 }
 
 #[test]
-fn example_sample_output() {
-    let output = get_example_output("sample");
+fn docs_sample_output() {
+    let output = get_docs_output("sample");
     let stdout = String::from_utf8_lossy(&output.stdout);
 
     assert!(output.status.success());
@@ -23,13 +23,13 @@ fn example_sample_output() {
 }
 
 #[test]
-fn example_sample_no_panic() {
+fn docs_sample_no_panic() {
     docs::Command::run(&sub::Docs::Sample)
 }
 
 #[test]
-fn example_view_output() {
-    let output = get_example_output("view");
+fn docs_view_output() {
+    let output = get_docs_output("view");
     let stdout = String::from_utf8_lossy(&output.stdout);
 
     assert!(output.status.success());
@@ -38,14 +38,16 @@ fn example_view_output() {
 }
 
 #[test]
-fn example_view_no_panic() {
+fn docs_view_no_panic() {
     docs::Command::run(&sub::Docs::View)
 }
 
 #[test]
-fn example_add_output() {
-    let output = get_example_output("add");
+fn docs_add_output() {
+    let output = get_docs_output("add");
     let stdout = String::from_utf8_lossy(&output.stdout);
+
+    dbg!(&output);
 
     assert!(output.status.success());
     assert!(stdout.contains("Usage: postit add <PRIORITY> <CONTENT> [--persister|-p]"));
@@ -53,13 +55,13 @@ fn example_add_output() {
 }
 
 #[test]
-fn example_add_no_panic() {
+fn docs_add_no_panic() {
     docs::Command::run(&sub::Docs::Add)
 }
 
 #[test]
-fn example_set_output() {
-    let output = get_example_output("set");
+fn docs_set_output() {
+    let output = get_docs_output("set");
     let stdout = String::from_utf8_lossy(&output.stdout);
 
     assert!(output.status.success());
@@ -68,13 +70,13 @@ fn example_set_output() {
 }
 
 #[test]
-fn example_set_no_panic() {
+fn docs_set_no_panic() {
     docs::Command::run(&sub::Docs::Set)
 }
 
 #[test]
-fn example_check_output() {
-    let output = get_example_output("check");
+fn docs_check_output() {
+    let output = get_docs_output("check");
     let stdout = String::from_utf8_lossy(&output.stdout);
 
     assert!(output.status.success());
@@ -83,13 +85,13 @@ fn example_check_output() {
 }
 
 #[test]
-fn example_check_no_panic() {
+fn docs_check_no_panic() {
     docs::Command::run(&sub::Docs::Check)
 }
 
 #[test]
-fn example_uncheck_output() {
-    let output = get_example_output("uncheck");
+fn docs_uncheck_output() {
+    let output = get_docs_output("uncheck");
     let stdout = String::from_utf8_lossy(&output.stdout);
 
     assert!(output.status.success());
@@ -98,13 +100,13 @@ fn example_uncheck_output() {
 }
 
 #[test]
-fn example_uncheck_no_panic() {
+fn docs_uncheck_no_panic() {
     docs::Command::run(&sub::Docs::Uncheck)
 }
 
 #[test]
-fn example_drop_output() {
-    let output = get_example_output("drop");
+fn docs_drop_output() {
+    let output = get_docs_output("drop");
     let stdout = String::from_utf8_lossy(&output.stdout);
 
     assert!(output.status.success());
@@ -113,13 +115,13 @@ fn example_drop_output() {
 }
 
 #[test]
-fn example_drop_no_panic() {
+fn docs_drop_no_panic() {
     docs::Command::run(&sub::Docs::Drop);
 }
 
 #[test]
-fn example_copy_output() {
-    let output = get_example_output("copy");
+fn docs_copy_output() {
+    let output = get_docs_output("copy");
     let stdout = String::from_utf8_lossy(&output.stdout);
 
     assert!(output.status.success());
@@ -128,13 +130,13 @@ fn example_copy_output() {
 }
 
 #[test]
-fn example_copy_no_panic() {
+fn docs_copy_no_panic() {
     docs::Command::run(&sub::Docs::Copy)
 }
 
 #[test]
-fn example_clean_output() {
-    let output = get_example_output("clean");
+fn docs_clean_output() {
+    let output = get_docs_output("clean");
     let stdout = String::from_utf8_lossy(&output.stdout);
 
     assert!(output.status.success());
@@ -143,13 +145,13 @@ fn example_clean_output() {
 }
 
 #[test]
-fn example_clean_no_panic() {
+fn docs_clean_no_panic() {
     docs::Command::run(&sub::Docs::Clean)
 }
 
 #[test]
-fn example_remove_output() {
-    let output = get_example_output("remove");
+fn docs_remove_output() {
+    let output = get_docs_output("remove");
     let stdout = String::from_utf8_lossy(&output.stdout);
 
     assert!(output.status.success());
@@ -158,13 +160,13 @@ fn example_remove_output() {
 }
 
 #[test]
-fn example_remove_no_panic() {
+fn docs_remove_no_panic() {
     docs::Command::run(&sub::Docs::Remove)
 }
 
 #[test]
-fn example_config_output() {
-    let output = get_example_output("config");
+fn docs_config_output() {
+    let output = get_docs_output("config");
     let stdout = String::from_utf8_lossy(&output.stdout);
 
     assert!(output.status.success());
@@ -174,6 +176,6 @@ fn example_config_output() {
 }
 
 #[test]
-fn example_config_no_panic() {
+fn docs_config_no_panic() {
     docs::Command::run(&sub::Docs::Config)
 }


### PR DESCRIPTION
# New
- Special parameters 'from' and 'to' in the 'copy' command.

# Changes
- Renamed 'example' command to 'docs'