### PR TITLE
Feature/check inline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 name: Build
 
-on: 
+on:
   push:
     branches: [master]
   pull_request:

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ postit is a simple CLI utility aimed to help you manage and keep track of your t
 
 - [From 0.1.x to 0.2.x](#from-01x-to-02x): brief migration guide.
 - [Getting started](#getting-started): describes installation and first steps.
-- [Features](#features): postit's functionalities and new additions roadmap. 
+- [Features](#features): postit's functionalities and new additions roadmap.
 - [Configuration](#configuration): describes configuration options.
 
 ## From 0.1.x to 0.2.x
@@ -29,7 +29,7 @@ as some basic commands to manage tasks and the configuration file.
 By bumping the version to 0.2.x, it is intended to mark the first great step
 of postit to becoming a more serious product.
 
-To migrate from 0.1.x to 0.2.x, you'll need to change the `--path` flag to 
+To migrate from 0.1.x to 0.2.x, you'll need to change the `--path` flag to
 `--persister` (pretty simple, right?).
 
 This minor will be focused on providing support for more database systems
@@ -56,7 +56,7 @@ On Linux:
 
 # Feel free to change this line
 export POSTIT_ROOT="$HOME/.postit"
-```  
+```
 
 On Windows:
 

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -92,7 +92,6 @@ pub struct Config {
 }
 
 impl Default for Config {
-    #[inline]
     fn default() -> Self {
         Self {
             persister: String::from("tasks.csv"),
@@ -104,7 +103,6 @@ impl Default for Config {
 }
 
 impl fmt::Display for Config {
-    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         writeln!(f, "persister: {}", self.persister)?;
         writeln!(f, "force_drop: {}", self.force_drop)?;
@@ -136,7 +134,6 @@ impl Config {
     /// # Errors
     /// - The path can't be obtained.
     /// - The config file already exists at the used path.
-    #[inline]
     pub fn init() -> Result<()> {
         let path = Self::path()?;
 
@@ -165,7 +162,6 @@ impl Config {
     ///
     /// # Errors
     /// - The `POSTIT_ROOT` exists but is empty.
-    #[inline]
     pub fn print_env() -> Result<()> {
         let env = Self::env().unwrap_or_default();
 
@@ -183,7 +179,6 @@ impl Config {
     /// # Errors
     /// - The file doesn't exist at the parent path.
     /// - The path can't be obtained from the `POSTIT_ROOT` env var.
-    #[inline]
     pub fn print_path() -> Result<()> {
         Self::_check_path_exists()?;
 
@@ -202,7 +197,6 @@ impl Config {
     ///
     /// # Panics
     /// - The parent can't be obtained from the path.
-    #[inline]
     pub fn remove() -> Result<()> {
         let path = Self::path()?;
 
@@ -226,7 +220,6 @@ impl Config {
     /// # Errors
     /// - The file doesn't exist at the parent path (displays default config too).
     /// - The configuration can't be loaded.
-    #[inline]
     pub fn list() -> Result<()> {
         let result = Self::_check_path_exists();
 
@@ -249,7 +242,6 @@ impl Config {
     /// - The file doesn't exist at the parent path.
     /// - There are no values provided.
     /// - The configuration can't be loaded.
-    #[inline]
     pub fn set(args: args::ConfigSet) -> Result<()> {
         Self::_check_path_exists()?;
 
@@ -314,7 +306,6 @@ impl Config {
     /// - The `POSTIT_ROOT` exists but is empty.
     /// - The value of `POSTIT_ROOT` contains not unicode characters.
     /// - The path from `POSTIT_ROOT` is relative.
-    #[inline]
     pub fn path_from_env() -> Result<PathBuf> {
         let env = Self::env();
 
@@ -369,7 +360,6 @@ impl Config {
     ///
     /// # Panics
     /// - The parent can't be obtained from the path.
-    #[inline]
     pub fn _check_path_exists() -> Result<()> {
         let path = Self::path()?;
 
@@ -403,7 +393,6 @@ impl Config {
     /// # Panics
     /// - If the path can't be converted to str.
     /// - If the parent path can't be converted to str.
-    #[inline]
     pub fn build_path<T: AsRef<Path>>(path: T) -> Result<PathBuf> {
         let path = path.as_ref();
 
@@ -421,7 +410,6 @@ impl Config {
     /// # Errors
     /// - The config file can't be loaded.
     /// - The config file can't be read.
-    #[inline]
     pub fn load() -> Result<Self> {
         let path = Self::path()?;
 
@@ -446,7 +434,6 @@ impl Config {
     /// - The config file can't be created.
     /// - The config can't be formatted to TOML.
     /// - The config file can't be saved.
-    #[inline]
     pub fn save(&self) -> Result<()> {
         let path = Self::path()?;
 

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -29,7 +29,6 @@ pub enum Action {
 }
 
 impl fmt::Display for Action {
-    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             Self::Check => write!(f, "check"),

--- a/src/core/postit.rs
+++ b/src/core/postit.rs
@@ -59,7 +59,6 @@ impl Postit {
     ///
     /// # Errors
     /// - The persister can't be obtained.
-    #[inline]
     pub fn get_persister<T>(persister: Option<T>) -> crate::Result<Box<dyn Persister>>
     where
         T: AsRef<str>,
@@ -78,16 +77,19 @@ impl Postit {
     }
 
     /// Shows use cases for every other command.
+    #[inline]
     fn docs(args: &args::Docs) {
         Docs::run(&args.subcommand);
     }
 
     /// Shows the list of current tasks.
+    #[inline]
     fn view(args: args::Persister) -> super::Result<()> {
         Self::get_persister(args.persister)?.view()
     }
 
     /// Adds a new task to the list.
+    #[inline]
     fn add(args: args::Add) -> super::Result<()> {
         let persister = Self::get_persister(args.persister)?;
 
@@ -108,6 +110,7 @@ impl Postit {
     }
 
     /// Changes the values of a task depending on the `Set` variant.
+    #[inline]
     fn set(args: args::Set) -> super::Result<()> {
         let persister = Self::get_persister(args.persister)?;
 
@@ -131,6 +134,7 @@ impl Postit {
     }
 
     /// Edits tasks based on the action passed.
+    #[inline]
     fn edit(args: args::Edit, action: &Action) -> super::Result<()> {
         let persister = Self::get_persister(args.persister)?;
 
@@ -158,7 +162,8 @@ impl Postit {
     /// # Errors
     /// - Both persisters are the same.
     /// - The left persister has no tasks.
-    /// - The right persister has tasks.    
+    /// - The right persister has tasks.
+    #[inline]
     fn copy(args: &args::Copy) -> super::Result<()> {
         let config = Config::load()?;
 
@@ -207,6 +212,7 @@ impl Postit {
     }
 
     /// Populates the persister with fake data for testing purposes.
+    #[inline]
     fn sample(args: args::Persister) -> super::Result<()> {
         let persister = Self::get_persister(args.persister)?;
 
@@ -222,16 +228,19 @@ impl Postit {
     }
 
     /// Cleans the tasks from a file.
+    #[inline]
     fn clean(args: args::Persister) -> super::Result<()> {
         Self::get_persister(args.persister)?.clean()
     }
 
     /// Removes a persister completely (file or table).
+    #[inline]
     fn remove(args: args::Persister) -> super::Result<()> {
         Self::get_persister(args.persister)?.remove()
     }
 
     /// Manages the configuration file.   
+    #[inline]
     fn config(args: args::Config) -> super::Result<()> {
         Ok(Config::manage(args.subcommand)?)
     }

--- a/src/core/postit.rs
+++ b/src/core/postit.rs
@@ -239,7 +239,7 @@ impl Postit {
         Self::get_persister(args.persister)?.remove()
     }
 
-    /// Manages the configuration file.   
+    /// Manages the configuration file.
     #[inline]
     fn config(args: args::Config) -> super::Result<()> {
         Ok(Config::manage(args.subcommand)?)

--- a/src/docs.rs
+++ b/src/docs.rs
@@ -93,7 +93,7 @@ Usage: postit add <PRIORITY> <CONTENT> [--persister|-p]
 Alias: postit a ...
 
 Description:
-    Creates a task with the format 'id,content,priority,checked': 
+    Creates a task with the format 'id,content,priority,checked':
     - id: a unique unsigned integer.
     - content: description of the task.
     - priority: high, med, low or none.
@@ -187,7 +187,7 @@ Alias: postit s ...
 
 Description:
     Changes the value of task's properties.
-    
+
     These are the available subcommands:
     - content: postit set content <CONTENT> [IDS]...
     - priority: postit set priority <PRIORITY> [IDS]..."
@@ -271,7 +271,7 @@ How to use:
             println!(
                 "
 Config:
-    You can set the 'force_drop' config to 'true' to drop tasks whether 
+    You can set the 'force_drop' config to 'true' to drop tasks whether
     they are checked or not.
 "
             );
@@ -332,7 +332,7 @@ Description:
 
 How to use:
     postit copy tasks.csv tasks.json
-    
+
     postit copy tasks.xml tasks.db
 
     postit copy tasks.db tasks.json
@@ -449,7 +449,7 @@ Config values:
 
     - drop_after_copy (bool): false by default.
       If 'true', drops a persister (file or table) after copying.
-    
+
 You can also check https://docs.rs/postit/latest/postit/struct.Config.html for more info."
         );
     }
@@ -485,9 +485,9 @@ How to use:
     postit view --persister tasks.db
 
     postit view --persister mongodb://localhost:27017
-    
+
     postit view --persister mongodb+srv://my_user:my_pass@cluster.mongodb.net
-    
+
     ..."
         );
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,11 +12,7 @@
 //!
 //! To get more info, run `postit -h` or take a look to the README file.
 
-#![warn(
-    clippy::missing_docs_in_private_items,
-    clippy::missing_inline_in_public_items,
-    missing_docs
-)]
+#![warn(clippy::missing_docs_in_private_items, missing_docs)]
 #![allow(
     // TMP
     clippy::expect_used,

--- a/src/models/task.rs
+++ b/src/models/task.rs
@@ -51,7 +51,6 @@ pub enum Priority {
 
 impl<T: AsRef<str>> From<T> for Priority {
     /// Transforms a string slice into a `Priority` variant.
-    #[inline]
     fn from(s: T) -> Self {
         match s.as_ref().to_lowercase().trim() {
             "high" => Self::High,
@@ -64,7 +63,6 @@ impl<T: AsRef<str>> From<T> for Priority {
 
 impl Priority {
     /// Returns the `Priority` value as its string representation.
-    #[inline]
     pub const fn to_str(&self) -> &str {
         match *self {
             Self::High => "high",
@@ -76,7 +74,6 @@ impl Priority {
 }
 
 impl fmt::Display for Priority {
-    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             Self::High => write!(f, "high"),
@@ -103,7 +100,6 @@ pub struct Task {
 }
 
 impl fmt::Display for Task {
-    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let msg = format!("{}. {}", self.id, self.content);
 
@@ -123,7 +119,6 @@ impl fmt::Display for Task {
 }
 
 impl Default for Task {
-    #[inline]
     fn default() -> Self {
         Self {
             id: 0,
@@ -153,7 +148,6 @@ impl Task {
     /// # Panics
     /// - If the `id` field can't be obtained or there is an error parsing.
     /// - If the `content` field can't be obtained from the second index.
-    #[inline]
     pub fn split<T: AsRef<str>>(line: T) -> (u32, String, Priority, bool) {
         let list: Vec<&str> = line.as_ref().split(',').map(str::trim).collect();
 
@@ -184,7 +178,6 @@ impl Task {
     ///
     /// # Errors
     /// - The task is already checked.
-    #[inline]
     pub const fn check(&mut self) -> Result<&Self, error::Error> {
         if self.checked {
             Err(error::Error::AlreadyChecked { id: self.id })
@@ -198,7 +191,6 @@ impl Task {
     ///
     /// # Errors
     /// - The task is already unchecked.
-    #[inline]
     pub const fn uncheck(&mut self) -> Result<&Self, error::Error> {
         if self.checked {
             self.checked = false;

--- a/src/models/todo.rs
+++ b/src/models/todo.rs
@@ -185,7 +185,7 @@ impl Todo {
     }
 
     /// Drops a task from the list.
-    /// Returns a `Vec<u32>` containing the IDs of the tasks that changed.    
+    /// Returns a `Vec<u32>` containing the IDs of the tasks that changed.
     ///
     /// # Errors
     /// - If there are no tasks stored in the instance.

--- a/src/models/todo.rs
+++ b/src/models/todo.rs
@@ -45,7 +45,6 @@ impl Todo {
     }
 
     /// Returns tasks based on the ids passed.
-    #[inline]
     pub fn get(&self, ids: &[u32]) -> Vec<&Task> {
         self.tasks
             .iter()
@@ -54,7 +53,6 @@ impl Todo {
     }
 
     /// Returns tasks based on the ids passed.
-    #[inline]
     pub fn get_mut(&mut self, ids: &[u32]) -> Vec<&mut Task> {
         self.tasks
             .iter_mut()
@@ -63,7 +61,6 @@ impl Todo {
     }
 
     /// Initializes a `Todo` instance with fake data.
-    #[inline]
     pub fn sample() -> Self {
         Self::new(vec![
             Task::from("1,Task,high,false"),
@@ -77,7 +74,6 @@ impl Todo {
     ///
     /// # Errors
     /// - There are no tasks stored in the instance.
-    #[inline]
     pub fn view(&self) -> crate::Result<()> {
         if self.tasks.is_empty() {
             let err = "There are no tasks to print";
@@ -101,7 +97,6 @@ impl Todo {
     ///
     /// # Errors
     /// - Bubbled up from [`Todo::set_priority`] or [`Todo::set_content`].
-    #[inline]
     pub fn set(&mut self, cmnd: &sub::Set) -> crate::Result<()> {
         match cmnd {
             sub::Set::Priority(args) => self.set_priority(&args.ids, &args.priority),
@@ -113,7 +108,6 @@ impl Todo {
     ///
     /// # Errors
     /// - There are no tasks stored in the instance.
-    #[inline]
     pub fn set_priority(&mut self, ids: &[u32], priority: &Priority) -> crate::Result<()> {
         if self.tasks.is_empty() {
             let err = "There are no tasks to edit";
@@ -131,7 +125,6 @@ impl Todo {
     ///
     /// # Errors
     /// - There are no tasks stored in the instance.
-    #[inline]
     pub fn set_content(&mut self, ids: &[u32], content: &str) -> crate::Result<()> {
         if self.tasks.is_empty() {
             let err = "There are no tasks to edit";
@@ -150,7 +143,6 @@ impl Todo {
     ///
     /// # Errors
     /// - There are no tasks stored in the instance.
-    #[inline]
     pub fn check(&mut self, ids: &[u32]) -> crate::Result<Vec<u32>> {
         if self.tasks.is_empty() {
             let err = "There are no tasks to check";
@@ -174,7 +166,6 @@ impl Todo {
     ///
     /// # Errors
     /// - There are no tasks stored in the instance.
-    #[inline]
     pub fn uncheck(&mut self, ids: &[u32]) -> crate::Result<Vec<u32>> {
         if self.tasks.is_empty() {
             let err = "There are no tasks to uncheck";
@@ -199,7 +190,6 @@ impl Todo {
     /// # Errors
     /// - If there are no tasks stored in the instance.
     /// - The configuration can't be loaded.
-    #[inline]
     pub fn drop(&mut self, ids: &[u32]) -> crate::Result<Vec<u32>> {
         if self.tasks.is_empty() {
             let err = "There are no tasks to drop";

--- a/src/persisters/db/mongo.rs
+++ b/src/persisters/db/mongo.rs
@@ -22,7 +22,6 @@ pub struct Mongo {
 }
 
 impl Clone for Mongo {
-    #[inline]
     fn clone(&self) -> Self {
         Self {
             conn_str: self.conn_str.clone(),
@@ -37,7 +36,6 @@ impl Mongo {
     /// # Errors
     /// - [`ClientOptions`] can't be parsed.
     /// - [`Client`] couldn't be opened.
-    #[inline]
     pub fn from<T: AsRef<str>>(uri: T) -> super::Result<Self> {
         let uri = uri.as_ref();
 
@@ -54,13 +52,11 @@ impl Mongo {
     }
 
     /// Gets a handle to a database specified by name in the cluster the Client is connected to.
-    #[inline]
     pub fn db(&self) -> Database {
         self.connection.database(&self.database())
     }
 
     /// Gets a handle to a collection with type T specified by name of the database.
-    #[inline]
     pub fn collection<T: Send + Sync>(&self) -> Collection<T> {
         self.db().collection::<T>(&self.table())
     }
@@ -72,29 +68,25 @@ impl DbPersister for Mongo {
         Box::new(self)
     }
 
-    #[inline]
     fn conn(&self) -> String {
         self.conn_str.clone()
     }
 
-    #[inline]
     fn table(&self) -> String {
         String::from("tasks")
     }
 
-    #[inline]
     fn database(&self) -> String {
+        // TODO: change to postit
         String::from("test")
     }
 
-    #[inline]
     fn exists(&self) -> super::Result<bool> {
         let names = self.db().list_collection_names().run()?;
 
         Ok(names.contains(&self.table()))
     }
 
-    #[inline]
     fn tasks(&self) -> super::Result<Vec<Task>> {
         if !self.exists()? {
             let err = format!(
@@ -114,7 +106,6 @@ impl DbPersister for Mongo {
         Ok(tasks)
     }
 
-    #[inline]
     fn count(&self) -> super::Result<u32> {
         if !self.exists()? {
             return Ok(0);
@@ -130,7 +121,6 @@ impl DbPersister for Mongo {
         Ok(n)
     }
 
-    #[inline]
     fn create(&self) -> super::Result<()> {
         let table = self.table();
 
@@ -141,7 +131,6 @@ impl DbPersister for Mongo {
         Ok(())
     }
 
-    #[inline]
     fn insert(&self, todo: &Todo) -> super::Result<()> {
         let docs: Vec<Document> = todo
             .tasks
@@ -161,7 +150,6 @@ impl DbPersister for Mongo {
         Ok(())
     }
 
-    #[inline]
     fn update(&self, todo: &Todo, ids: &[u32], action: &Action) -> super::Result<()> {
         if matches!(action, Action::Drop) {
             return self.delete(ids);
@@ -187,7 +175,6 @@ impl DbPersister for Mongo {
         Ok(())
     }
 
-    #[inline]
     fn delete(&self, ids: &[u32]) -> super::Result<()> {
         let query = doc! { "id": {"$in": ids }};
 
@@ -196,7 +183,6 @@ impl DbPersister for Mongo {
         Ok(())
     }
 
-    #[inline]
     fn drop_table(&self) -> super::Result<()> {
         self.collection::<Task>().drop().run()?;
 
@@ -205,7 +191,6 @@ impl DbPersister for Mongo {
         Ok(())
     }
 
-    #[inline]
     fn drop_database(&self) -> super::Result<()> {
         self.db().drop().run()?;
 
@@ -214,7 +199,6 @@ impl DbPersister for Mongo {
         Ok(())
     }
 
-    #[inline]
     fn clean(&self) -> super::Result<()> {
         self.collection::<String>().delete_many(doc! {}).run()?;
 

--- a/src/persisters/db/orm.rs
+++ b/src/persisters/db/orm.rs
@@ -30,7 +30,6 @@ pub enum Protocol {
 
 impl<T: AsRef<str>> From<T> for Protocol {
     /// Transforms a string slice into a `Protocol` variant.
-    #[inline]
     fn from(s: T) -> Self {
         match s.as_ref().to_lowercase().trim() {
             "sqlite" => Self::Sqlite,
@@ -46,7 +45,6 @@ impl<T: AsRef<str>> From<T> for Protocol {
 
 impl Protocol {
     /// Returns the `Protocol` value as its string representation.
-    #[inline]
     pub const fn to_str(&self) -> &str {
         match *self {
             Self::Sqlite => "sqlite",
@@ -57,7 +55,6 @@ impl Protocol {
 }
 
 impl fmt::Display for Protocol {
-    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             Self::Sqlite => write!(f, "sqlite"),
@@ -74,7 +71,6 @@ pub struct Orm {
 }
 
 impl fmt::Debug for Orm {
-    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Orm")
             .field("db", &self.to_string())
@@ -94,7 +90,6 @@ impl Orm {
     ///
     /// # Errors
     /// - The database persister can't be obtained.
-    #[inline]
     pub fn from<T: AsRef<str>>(conn: T) -> crate::Result<Self> {
         Ok(Self { db: Self::get_persister(conn)? })
     }
@@ -118,7 +113,6 @@ impl Orm {
     /// # Errors
     /// - If the persister can't be obtained.
     /// - If the connection string is empty.
-    #[inline]
     pub fn get_persister<T: AsRef<str>>(conn: T) -> crate::Result<Box<dyn DbPersister>> {
         let conn = conn.as_ref();
 
@@ -151,12 +145,10 @@ impl Persister for Orm {
         Box::new(self)
     }
 
-    #[inline]
     fn to_string(&self) -> String {
         self.db.conn()
     }
 
-    #[inline]
     fn create(&self) -> crate::Result<()> {
         self.db.create().map_err(|e| {
             eprintln!("Can't create the table");
@@ -164,7 +156,6 @@ impl Persister for Orm {
         })
     }
 
-    #[inline]
     fn exists(&self) -> crate::Result<bool> {
         self.db.exists().map_err(|e| {
             eprintln!("The table doesn't exist; add a task first to use this command");
@@ -172,17 +163,14 @@ impl Persister for Orm {
         })
     }
 
-    #[inline]
     fn view(&self) -> crate::Result<()> {
         Todo::new(self.tasks()?).view()
     }
 
-    #[inline]
     fn tasks(&self) -> crate::Result<Vec<Task>> {
         Ok(self.db.tasks()?)
     }
 
-    #[inline]
     fn edit(&self, todo: &Todo, ids: &[u32], action: &Action) -> crate::Result<()> {
         self.db.update(todo, ids, action).map_err(|e| {
             eprintln!("Can't perform the '{action}' action");
@@ -190,7 +178,6 @@ impl Persister for Orm {
         })
     }
 
-    #[inline]
     fn save(&self, todo: &Todo) -> crate::Result<()> {
         if self.db.count()? == 0 {
             return self.db.insert(todo).map_err(|e| {
@@ -208,7 +195,6 @@ impl Persister for Orm {
         })
     }
 
-    #[inline]
     fn replace(&self, todo: &Todo) -> crate::Result<()> {
         if self.exists()? {
             self.db.clean()?;
@@ -224,7 +210,6 @@ impl Persister for Orm {
         Ok(())
     }
 
-    #[inline]
     fn clean(&self) -> crate::Result<()> {
         if self.tasks()?.is_empty() {
             eprintln!("There are no tasks to delete in the table");
@@ -241,7 +226,6 @@ impl Persister for Orm {
         Ok(())
     }
 
-    #[inline]
     fn remove(&self) -> crate::Result<()> {
         let table = self.db.table();
 

--- a/src/persisters/db/sqlite.rs
+++ b/src/persisters/db/sqlite.rs
@@ -21,7 +21,6 @@ pub struct Sqlite {
 }
 
 impl fmt::Debug for Sqlite {
-    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Sqlite")
             .field("conn_str", &self.conn_str)
@@ -31,7 +30,6 @@ impl fmt::Debug for Sqlite {
 }
 
 impl Clone for Sqlite {
-    #[inline]
     fn clone(&self) -> Self {
         Self {
             conn_str: self.conn_str.clone(),
@@ -49,7 +47,6 @@ impl Sqlite {
     ///
     /// # Panics
     /// - The path can't be converted to &str.
-    #[inline]
     pub fn from<T: AsRef<Path>>(conn: T) -> crate::Result<Self> {
         let path = Config::build_path(conn.as_ref())?;
 
@@ -66,7 +63,6 @@ impl Sqlite {
     }
 
     /// Returns the desired ids format to be used in a query.
-    #[inline]
     pub fn format_ids(&self, ids: &[u32]) -> String {
         ids.iter()
             .map(|&n| n.to_string())
@@ -78,7 +74,6 @@ impl Sqlite {
     ///
     /// # Errors
     /// - A value can't be read.
-    #[inline]
     pub fn read_row(&self, stmt: &Statement) -> super::Result<String> {
         let row = format!(
             "{},{},{},{}",
@@ -95,7 +90,6 @@ impl Sqlite {
     ///
     /// # Errors
     /// - The statement can't be evaluated.
-    #[inline]
     pub fn reset_autoincrement(&self, table: &str) -> sqlite::Result<State> {
         #[rustfmt::skip]
         let query = format!("
@@ -114,17 +108,14 @@ impl DbPersister for Sqlite {
         Box::new(self)
     }
 
-    #[inline]
     fn conn(&self) -> String {
         self.conn_str.clone()
     }
 
-    #[inline]
     fn table(&self) -> String {
         String::from("tasks")
     }
 
-    #[inline]
     fn database(&self) -> String {
         Path::new(&self.conn_str)
             .file_name()
@@ -139,7 +130,6 @@ impl DbPersister for Sqlite {
     /// # Errors
     /// - The statement can't be prepared.
     /// - The name column can't be read.
-    #[inline]
     fn exists(&self) -> super::Result<bool> {
         #[rustfmt::skip]
         let query = format!("
@@ -160,7 +150,6 @@ impl DbPersister for Sqlite {
         Ok(!result.is_empty())
     }
 
-    #[inline]
     fn tasks(&self) -> super::Result<Vec<Task>> {
         if !self.exists()? {
             let err = format!(
@@ -182,7 +171,6 @@ impl DbPersister for Sqlite {
         Ok(result)
     }
 
-    #[inline]
     fn count(&self) -> super::Result<u32> {
         if !self.exists()? {
             return Ok(0);
@@ -198,7 +186,6 @@ impl DbPersister for Sqlite {
         Ok(n)
     }
 
-    #[inline]
     fn create(&self) -> super::Result<()> {
         #[rustfmt::skip]
         let query = format!("
@@ -217,7 +204,6 @@ impl DbPersister for Sqlite {
         Ok(())
     }
 
-    #[inline]
     fn insert(&self, todo: &Todo) -> super::Result<()> {
         #[rustfmt::skip]
         let query = format!("
@@ -243,7 +229,6 @@ impl DbPersister for Sqlite {
         Ok(())
     }
 
-    #[inline]
     fn update(&self, todo: &Todo, ids: &[u32], action: &Action) -> super::Result<()> {
         if matches!(action, Action::Drop) {
             return self.delete(ids);
@@ -272,7 +257,6 @@ impl DbPersister for Sqlite {
         Ok(())
     }
 
-    #[inline]
     fn delete(&self, ids: &[u32]) -> super::Result<()> {
         #[rustfmt::skip]
         let query = format!("
@@ -288,7 +272,6 @@ impl DbPersister for Sqlite {
         Ok(())
     }
 
-    #[inline]
     fn drop_table(&self) -> super::Result<()> {
         let table = self.table();
         let query = format!("DROP TABLE {table}");
@@ -300,7 +283,6 @@ impl DbPersister for Sqlite {
         Ok(())
     }
 
-    #[inline]
     fn drop_database(&self) -> super::Result<()> {
         fs::remove_file(self.conn()).map_err(super::Error::wrap)?;
 
@@ -309,7 +291,6 @@ impl DbPersister for Sqlite {
         Ok(())
     }
 
-    #[inline]
     fn clean(&self) -> super::Result<()> {
         let table = self.table();
         let query = format!("DELETE FROM {table}");

--- a/src/persisters/fs/csv.rs
+++ b/src/persisters/fs/csv.rs
@@ -23,7 +23,6 @@ impl Csv {
     }
 
     /// Returns the header of a the csv file.
-    #[inline]
     pub fn header() -> String {
         String::from("id,content,priority,checked\n")
     }
@@ -40,12 +39,10 @@ impl FilePersister for Csv {
         &self.path
     }
 
-    #[inline]
     fn default(&self) -> String {
         Self::header()
     }
 
-    #[inline]
     fn tasks(&self) -> super::Result<Vec<Task>> {
         let lines: Vec<String> = fs::read_to_string(&self.path)?
             .lines()
@@ -58,12 +55,10 @@ impl FilePersister for Csv {
         Ok(tasks)
     }
 
-    #[inline]
     fn open(&self) -> super::Result<fs::File> {
         Ok(fs::File::open(&self.path)?)
     }
 
-    #[inline]
     fn write(&self, todo: &Todo) -> super::Result<()> {
         let sep = if cfg!(windows) { "\r\n" } else { "\n" };
 
@@ -83,14 +78,12 @@ impl FilePersister for Csv {
         Ok(())
     }
 
-    #[inline]
     fn clean(&self) -> super::Result<()> {
         fs::write(&self.path, self.default())?;
 
         Ok(())
     }
 
-    #[inline]
     fn remove(&self) -> super::Result<()> {
         fs::remove_file(&self.path)?;
 

--- a/src/persisters/fs/file.rs
+++ b/src/persisters/fs/file.rs
@@ -32,7 +32,6 @@ pub enum Format {
 
 impl<T: AsRef<str>> From<T> for Format {
     /// Transforms a string slice into a `Format` variant.
-    #[inline]
     fn from(s: T) -> Self {
         match s.as_ref().to_lowercase().trim() {
             "csv" => Self::Csv,
@@ -50,7 +49,6 @@ impl<T: AsRef<str>> From<T> for Format {
 
 impl Format {
     /// Returns the `Priority` value as its string representation.
-    #[inline]
     pub const fn to_str(&self) -> &str {
         match *self {
             Self::Csv => "csv",
@@ -69,7 +67,6 @@ pub struct File {
 }
 
 impl fmt::Debug for File {
-    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("File").field("file", &self.path()).finish()
     }
@@ -91,7 +88,6 @@ impl File {
     ///
     /// # Panics
     /// - The parent directory can't be obtained (only in case it has to be created).
-    #[inline]
     pub fn from<T: AsRef<str>>(path: T) -> crate::Result<Self> {
         let file_name = Self::check_name(path.as_ref());
         let file_path = Config::build_path(file_name)?;
@@ -117,7 +113,6 @@ impl File {
     ///
     /// # Panics
     /// - The file name can't be obtained.
-    #[inline]
     pub fn check_content(&self) -> crate::fs::Result<()> {
         let path = &self.path();
 
@@ -133,7 +128,6 @@ impl File {
     }
 
     /// Checks the format of a file and return the same instance with the correct format.
-    #[inline]
     pub fn check_name<T: AsRef<Path>>(path: T) -> PathBuf {
         let mut path = path.as_ref().to_path_buf();
 
@@ -166,7 +160,6 @@ impl File {
     ///
     /// # Panics
     /// - The file extension can't be converted to `&str`.
-    #[inline]
     pub fn get_persister<T: AsRef<Path>>(path: T) -> crate::Result<Box<dyn FilePersister>> {
         let mut file_path = path.as_ref().to_path_buf();
 
@@ -205,12 +198,10 @@ impl Persister for File {
         Box::new(self)
     }
 
-    #[inline]
     fn to_string(&self) -> String {
         self.path().to_str().unwrap().to_owned()
     }
 
-    #[inline]
     fn create(&self) -> crate::Result<()> {
         let path = self.path();
 
@@ -226,12 +217,10 @@ impl Persister for File {
         Ok(())
     }
 
-    #[inline]
     fn exists(&self) -> crate::Result<bool> {
         Ok(self.path().exists())
     }
 
-    #[inline]
     fn view(&self) -> crate::Result<()> {
         let path = self.path();
 
@@ -244,7 +233,6 @@ impl Persister for File {
         Ok(())
     }
 
-    #[inline]
     fn tasks(&self) -> crate::Result<Vec<Task>> {
         if !self.exists()? {
             return Ok(Vec::new());
@@ -253,7 +241,6 @@ impl Persister for File {
         Ok(self.file.tasks()?)
     }
 
-    #[inline]
     fn edit(&self, todo: &Todo, _ids: &[u32], action: &Action) -> crate::Result<()> {
         let path = self.path();
 
@@ -270,7 +257,6 @@ impl Persister for File {
         })
     }
 
-    #[inline]
     fn save(&self, todo: &Todo) -> crate::Result<()> {
         self.file.write(todo).map_err(|e| {
             let path = self.path();
@@ -282,7 +268,6 @@ impl Persister for File {
         })
     }
 
-    #[inline]
     fn replace(&self, todo: &Todo) -> crate::Result<()> {
         let path = self.path();
         let file = path.file_name().unwrap().to_string_lossy();
@@ -297,7 +282,6 @@ impl Persister for File {
         Ok(())
     }
 
-    #[inline]
     fn clean(&self) -> crate::Result<()> {
         let path = self.path();
         let file = path.to_path_buf();
@@ -316,7 +300,6 @@ impl Persister for File {
         Ok(())
     }
 
-    #[inline]
     fn remove(&self) -> crate::Result<()> {
         let path = self.path();
         let file = path.to_path_buf();
@@ -337,7 +320,6 @@ impl Persister for File {
 }
 
 impl PartialEq for File {
-    #[inline]
     fn eq(&self, other: &Self) -> bool {
         (self.to_string() == other.to_string()) && (self.tasks().unwrap() == other.tasks().unwrap())
     }

--- a/src/persisters/fs/json.rs
+++ b/src/persisters/fs/json.rs
@@ -23,7 +23,6 @@ impl Json {
     }
 
     /// Returns the basic structure to initialize a JSON file.
-    #[inline]
     pub fn array() -> String {
         String::from("[]")
     }
@@ -40,12 +39,10 @@ impl FilePersister for Json {
         &self.path
     }
 
-    #[inline]
     fn default(&self) -> String {
         Self::array()
     }
 
-    #[inline]
     fn tasks(&self) -> super::Result<Vec<Task>> {
         let content = fs::read_to_string(&self.path)?;
         let tasks = serde_json::from_str(content.trim())?;
@@ -53,7 +50,6 @@ impl FilePersister for Json {
         Ok(tasks)
     }
 
-    #[inline]
     fn open(&self) -> super::Result<fs::File> {
         let file = fs::OpenOptions::new()
             .read(true)
@@ -65,21 +61,18 @@ impl FilePersister for Json {
         Ok(file)
     }
 
-    #[inline]
     fn write(&self, todo: &Todo) -> super::Result<()> {
         serde_json::to_writer_pretty(self.open()?, &todo.tasks)?;
 
         Ok(())
     }
 
-    #[inline]
     fn clean(&self) -> super::Result<()> {
         fs::write(&self.path, self.default())?;
 
         Ok(())
     }
 
-    #[inline]
     fn remove(&self) -> super::Result<()> {
         fs::remove_file(&self.path)?;
 

--- a/src/persisters/fs/xml.rs
+++ b/src/persisters/fs/xml.rs
@@ -28,33 +28,30 @@ impl Xml {
     }
 
     /// Basic structure to initialize a XML file.
-    #[inline]
-    pub fn prolog() -> String {
-        String::from(r#"<?xml version="1.0" encoding="UTF-8"?>"#) + "\n"
+    pub const fn prolog() -> &'static str {
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+"#
     }
 
     /// Document Type Definition of a XML file.
     #[rustfmt::skip]
-    #[inline]
-    pub fn dtd() -> String {
-        String::from(
-"<!DOCTYPE Tasks [
+    pub const fn dtd() -> &'static str {
+        "<!DOCTYPE Tasks [
     <!ELEMENT Tasks (Task+)>
     <!ELEMENT Task (#PCDATA)>
-    <!ATTLIST Task 
+    <!ATTLIST Task
         id CDATA #REQUIRED
         priority (low | med | high | none) #REQUIRED
         checked (true | false) #REQUIRED
     >
-]>\n",
-        )
+]>
+"
     }
 
     /// Writes a [Todo] instance into XML writer and returns a buffer with the content.
     ///
     /// # Errors
     /// - The XML Event can't be written.
-    #[inline]
     pub fn todo_to_xml(todo: &Todo) -> super::Result<Vec<u8>> {
         let mut buffer = Vec::new();
         let mut writer = Writer::new_with_indent(&mut buffer, b' ', 4);
@@ -74,7 +71,6 @@ impl Xml {
     ///
     /// # Errors
     /// - The XML Event can't be written.
-    #[inline]
     pub fn task_to_xml(writer: &mut Writer<&mut Vec<u8>>, task: &Task) -> io::Result<()> {
         let mut task_bytes = BytesStart::new("Task");
         task_bytes.push_attribute(("id", task.id.to_string().as_str()));
@@ -92,7 +88,6 @@ impl Xml {
     ///
     /// # Errors
     /// - A value can't be unescaped.
-    #[inline]
     pub fn xml_to_tasks(mut reader: Reader<&[u8]>) -> super::Result<Vec<Task>> {
         let mut tasks = vec![];
         let mut task = None::<Task>;
@@ -155,10 +150,9 @@ impl FilePersister for Xml {
 
     #[inline]
     fn default(&self) -> String {
-        Self::prolog() + &Self::dtd()
+        String::from(Self::prolog()) + Self::dtd()
     }
 
-    #[inline]
     fn tasks(&self) -> super::Result<Vec<Task>> {
         let xml = fs::read_to_string(&self.path)?;
         let reader = Reader::from_str(xml.trim());
@@ -166,7 +160,6 @@ impl FilePersister for Xml {
         Self::xml_to_tasks(reader)
     }
 
-    #[inline]
     fn open(&self) -> super::Result<fs::File> {
         let file = fs::OpenOptions::new()
             .read(true)
@@ -178,7 +171,6 @@ impl FilePersister for Xml {
         Ok(file)
     }
 
-    #[inline]
     fn write(&self, todo: &Todo) -> super::Result<()> {
         let buffer = Self::todo_to_xml(todo)?;
         let xml = String::from_utf8(buffer).map_err(super::Error::wrap)?;
@@ -190,14 +182,12 @@ impl FilePersister for Xml {
         Ok(())
     }
 
-    #[inline]
     fn clean(&self) -> super::Result<()> {
         fs::write(&self.path, self.default())?;
 
         Ok(())
     }
 
-    #[inline]
     fn remove(&self) -> super::Result<()> {
         fs::remove_file(&self.path)?;
 

--- a/src/persisters/traits.rs
+++ b/src/persisters/traits.rs
@@ -77,14 +77,12 @@ pub trait Persister: fmt::Debug {
 }
 
 impl PartialEq for Box<dyn Persister> {
-    #[inline]
     fn eq(&self, other: &Self) -> bool {
         (self.to_string() == other.to_string()) && (self.tasks().unwrap() == other.tasks().unwrap())
     }
 }
 
 impl Clone for Box<dyn Persister> {
-    #[inline]
     fn clone(&self) -> Self {
         crate::Postit::get_persister(Some(self.to_string())).unwrap()
     }
@@ -133,7 +131,6 @@ pub trait FilePersister: Debug {
 }
 
 impl PartialEq for Box<dyn FilePersister> {
-    #[inline]
     fn eq(&self, other: &Self) -> bool {
         (self.path() == other.path()) && (self.tasks().unwrap() == other.tasks().unwrap())
     }
@@ -217,7 +214,6 @@ pub trait DbPersister: Debug {
 
 #[cfg(any(feature = "mongo", feature = "sqlite"))]
 impl PartialEq for Box<dyn DbPersister> {
-    #[inline]
     fn eq(&self, other: &Self) -> bool {
         (self.conn() == other.conn()) && (self.tasks().unwrap() == other.tasks().unwrap())
     }

--- a/tests/persisters/fs/xml.rs
+++ b/tests/persisters/fs/xml.rs
@@ -13,7 +13,7 @@ fn default() -> postit::Result<()> {
     let mock = MockPath::create(Format::Xml)?;
 
     let result = Xml::new(mock.path()).default();
-    let expect = Xml::prolog() + &Xml::dtd();
+    let expect = String::from(Xml::prolog()) + Xml::dtd();
 
     assert_eq!(result, expect);
 


### PR DESCRIPTION
Inlines are used by the compiler to reduce jumping to functions and expose the public API to other crates so they can be compiled by other crates that depend on them when LTO is disabled.

This PR reduces unnecessary inlines for correctness rather than performance, as postit is not a dependency and should not worry about LTO issues (at least right now).

## Benchmark

I compiled postit around 50 times (overall) with:
```sh
# Compile base dependencies
cargo build
cargo build -r

# Compile all dependencies
cargo build --all-features
cargo build -r --all-features
```

These are the average execution times in seconds for each iteration, each one consisting of at least 5 warm-up runs:  

### Before

```sh
# No features
- Debug: 7.12 s
- Release: 8.64 s

# All features
- Debug: 31.28 s
- Release: 45.90 s
```

### After

```sh
# No features
- Debug: 6.85 s
- Release: 8.49 s

# All features
- Debug: 27.13 s
- Release: 45.00 s
```

## Links

- https://rust-lang.github.io/rust-clippy/rust-1.95.0/index.html#missing_inline_in_public_items
- https://nnethercote.github.io/perf-book/inlining.html